### PR TITLE
fix: prevent Render services sleep by adding health checks endpoints

### DIFF
--- a/backend/python/health.py
+++ b/backend/python/health.py
@@ -1,0 +1,9 @@
+from flask import Flask
+app = Flask(__name__)
+
+@app.route("/health")
+def health():
+    return "OK", 200
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/backend/src/main/java/com/tunereveal/backend/HealthController.java
+++ b/backend/src/main/java/com/tunereveal/backend/HealthController.java
@@ -1,0 +1,13 @@
+package com.tunereveal.backend;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+    @GetMapping("/health")
+    public ResponseEntity<String> health() {
+        return ResponseEntity.ok("OK");
+    }
+}


### PR DESCRIPTION
Add `/health` endpoints to Spring Boot and Python services for UptimeRobot monitoring, ensuring Render services stay active by periodic pings (5min intervals).  